### PR TITLE
Fix redirect when submit dialog

### DIFF
--- a/js/ocPassman.js
+++ b/js/ocPassman.js
@@ -266,6 +266,7 @@ jQuery(document).ready(function($) {
 
 	$('#editAddItemDialog .cancel').click(function() {
 		$('#editAddItemDialog').dialog('close');
+		return false;
 	});
 
 	$(document).on('click', '#showPW', function() {
@@ -321,8 +322,9 @@ jQuery(document).ready(function($) {
 	});
 
 	$('#editAddItemDialog .save').click(function(){
-		saveItem()
-		$(this).prop('disabled','disabled');
+		saveItem();
+		$(this).removeAttr('disabled');
+		return false;
 	});
 
 	$('#folderSettingsDialog .cancel').click(function() {


### PR DESCRIPTION
Hi !

This is a annoying bug that appear some commit before (don't know witch).
When you validate a new/edit a password, you were redirect on /apps/passman/ instead of doing an ajax request.
Same for the Cancel button.
For some reason, jQuery force to validate the form when you don't return false en button click.

This fix also a problem appear after fixing the previous bug : the Save button, if you fail something, kept disabled.

Have a nice day ! :-) 

PS / EDIT : I use master, this bug don't appear on current released version 
