### PR TITLE
fix firefox download attribute : need to be placed in dom

### DIFF
--- a/js/ocPassman.js
+++ b/js/ocPassman.js
@@ -1299,6 +1299,7 @@ function loadFile(fileId) {
 						a.style = "display: none";
 						a.href = uriContent;
 						a.download = escapeHTML(decryptThis(data.filename));
+						document.body.appendChild(a);
 						a.click();
 						window.URL.revokeObjectURL(url);
 						$(this).remove();


### PR DESCRIPTION
Hello
Downloading a file added to an item did not worked on my firefox

this commit would solve this issue

Hope this help
