### PR TITLE
Fixing case sensitivity and grammar/orthography

### DIFF
--- a/templates/firstrun.php
+++ b/templates/firstrun.php
@@ -2,16 +2,16 @@
 	<div id="fieldsetContainer">
 		<fieldset>
 			<legend><?php p($l->t('Welcome')); ?></legend>
-				<?php p($l->t('Welcome to PassMan, the password manager for ownCloud!'));?>
+				<?php p($l->t('Welcome to Passman, the password manager for ownCloud!'));?>
 				<br />
 				<?php p($l->t('In the next steps you will learn how to use it.')); ?>
 		</fieldset>
 		<fieldset>
 			<legend><?php p($l->t('Tags')); ?></legend>
 			<?php p($l->t('These are your example tags.'));?><br />
-			<?php p($l->t('Tags can be assigned to passwords, giving them common properties like minimal')); ?> <span tool-tip title="<?php p($l->t('PassMan automatically computes a score for each password to estimate its strength. A higher score means a stronger password.')); ?>" style="border-bottom: 1px dashed black"><?php p($l->t('password score')); ?></span> <?php p($l->t('and renewal time.')); ?><br />
-			<?php p($l->t('For example, a "banking" tag could require a ')); ?><span tool-tip title="<?php p($l->t('PassMan automatically computes a score for each password to estimate its strength. A higher score means a stronger password.')); ?>" style="border-bottom: 1px dashed black"><?php p($l->t('password score')); ?></span> <?php p($l->t('of 60 and to be changed every month.')); ?><br />
-			<?php p($l->t('While a "forums" tag requires a ')); ?><span tool-tip title="<?php p($l->t('PassMan automatically computes a score for each password to estimate its strength. A higher score means a stronger password.')); ?>" style="border-bottom: 1px dashed black"><?php p($l->t('password score')); ?></span> <?php p($l->t('of 30 and to be changed every year.')); ?>
+			<?php p($l->t('Tags can be assigned to passwords, giving them common properties like minimal')); ?> <span tool-tip title="<?php p($l->t('Passman automatically computes a score for each password to estimate its strength. A higher score means a stronger password.')); ?>" style="border-bottom: 1px dashed black"><?php p($l->t('password score')); ?></span> <?php p($l->t('and renewal time.')); ?><br />
+			<?php p($l->t('For example, a "banking" tag could require a ')); ?><span tool-tip title="<?php p($l->t('Passman automatically computes a score for each password to estimate its strength. A higher score means a stronger password.')); ?>" style="border-bottom: 1px dashed black"><?php p($l->t('password score')); ?></span> <?php p($l->t('of 60 and to be changed every month.')); ?><br />
+			<?php p($l->t('While a "forums" tag requires a ')); ?><span tool-tip title="<?php p($l->t('Passman automatically computes a score for each password to estimate its strength. A higher score means a stronger password.')); ?>" style="border-bottom: 1px dashed black"><?php p($l->t('password score')); ?></span> <?php p($l->t('of 30 and to be changed every year.')); ?>
 			<br />
 			<br />
 			<b><?php p($l->t('Assignment: Change the example tags to your likings, then click next.')); ?></b>

--- a/templates/firstrun.php
+++ b/templates/firstrun.php
@@ -8,10 +8,10 @@
 		</fieldset>
 		<fieldset>
 			<legend><?php p($l->t('Tags')); ?></legend>
-			<?php p($l->t('This are your example tags.'));?><br />
-			<?php p($l->t('Tags can be assigned to passwords, giving them common properties like minimal')); ?> <span tool-tip title="<?php p($l->t('Passman automatically computes a score for each password to estimate its strength. A higher score means a stronger password.')); ?>" style="border-bottom: 1px dashed black"><?php p($l->t('password score')); ?></span> <?php p($l->t('and renewal time.')); ?><br />
-			<?php p($l->t('For example, a "banking" tag could require a ')); ?><span tool-tip title="<?php p($l->t('Passman automatically computes a score for each password to estimate its strength. A higher score means a stronger password.')); ?>" style="border-bottom: 1px dashed black"><?php p($l->t('password score')); ?></span> <?php p($l->t('of 60 and to be changed every month.')); ?><br />
-			<?php p($l->t('While a "forums" tag requires a ')); ?><span tool-tip title="<?php p($l->t('Passman automatically computes a score for each password to estimate its strength. A higher score means a stronger password.')); ?>" style="border-bottom: 1px dashed black"><?php p($l->t('password score')); ?></span> <?php p($l->t('of 30 and to be changed every year.')); ?>
+			<?php p($l->t('These are your example tags.'));?><br />
+			<?php p($l->t('Tags can be assigned to passwords, giving them common properties like minimal')); ?> <span tool-tip title="<?php p($l->t('PassMan automatically computes a score for each password to estimate its strength. A higher score means a stronger password.')); ?>" style="border-bottom: 1px dashed black"><?php p($l->t('password score')); ?></span> <?php p($l->t('and renewal time.')); ?><br />
+			<?php p($l->t('For example, a "banking" tag could require a ')); ?><span tool-tip title="<?php p($l->t('PassMan automatically computes a score for each password to estimate its strength. A higher score means a stronger password.')); ?>" style="border-bottom: 1px dashed black"><?php p($l->t('password score')); ?></span> <?php p($l->t('of 60 and to be changed every month.')); ?><br />
+			<?php p($l->t('While a "forums" tag requires a ')); ?><span tool-tip title="<?php p($l->t('PassMan automatically computes a score for each password to estimate its strength. A higher score means a stronger password.')); ?>" style="border-bottom: 1px dashed black"><?php p($l->t('password score')); ?></span> <?php p($l->t('of 30 and to be changed every year.')); ?>
 			<br />
 			<br />
 			<b><?php p($l->t('Assignment: Change the example tags to your likings, then click next.')); ?></b>
@@ -42,30 +42,30 @@
 				<li>
 					<b><?php p($l->t('General')); ?></b><br />
 					<?php p($l->t('Your general password info is here.')); ?><br />
-					<?php p($l->t('Eg: The label of the item, Login / username, email.')); ?><br />
-					<?php p($l->t('Also there is an password field.')); ?>
+					<?php p($l->t('E.g.: The label of the item, Login / username, email.')); ?><br />
+					<?php p($l->t('There is also a password field.')); ?>
 				</li>
 				<li>
 					<b><?php p($l->t('Password')); ?></b><br />
 					<?php p($l->t('Password generation & password generation settings.')); ?><br />
 					<?php p($l->t('If you require a more complex password, this is the tab you need')); ?><br />
-					<?php p($l->t('It has an build in password generator with many settings.')); ?>
+					<?php p($l->t('It has a built-in password generator with many settings.')); ?>
 				</li>
 				<li>
 					<b><?php p($l->t('Files')); ?></b><br />
-					<?php p($l->t('You can upload files, with a max of 5Mb.')); ?><br />
-					<?php p($l->t('Files are first encrypted with your encryption key and then send to the server.')); ?><br />
+					<?php p($l->t('You can upload files with a maximum of 5 MB.')); ?><br />
+					<?php p($l->t('Files are first encrypted with your encryption key and then sent to the server.')); ?><br />
 					<?php p($l->t('Because encryption / decryption is a complex process it can take a while on mobile phones.')); ?>
 				</li>
 				<li>
 					<b><?php p($l->t('Custom fields')); ?></b><br />
-					<?php p($l->t('If the default fields are not enough your you, then here you can add your own fields.')); ?><br />
+					<?php p($l->t('If the default fields are not enough your you, then you can add your own fields here.')); ?><br />
 					<?php p($l->t('It also offers an option to let the value be hidden so it is handled as a password.')); ?>
 				</li>
 				<li>
 					<b><?php p($l->t('OTP Settings')); ?></b><br />
-					<?php p($l->t('Passman has a build in OTP (One Time Password) generator.')); ?><br />
-					<?php p($l->t('If you don\'t know what a OTP is then i suggest you enable it.')); ?><br />
+					<?php p($l->t('Passman has a built-in OTP (One Time Password) generator.')); ?><br />
+					<?php p($l->t('If you don\'t know what a OTP is then I suggest you enable it.')); ?><br />
 					<?php p($l->t('Services that have options for a One Time Password')); ?><br />
 					- <a href="https://help.github.com/articles/about-two-factor-authentication/" target="_blank"><?php p($l->t('Github'));?></a><br />
 					- <a href="https://www.google.com/landing/2step/" target="_blank"><?php p($l->t('Google')); ?></a><br />

--- a/templates/firstrun.php
+++ b/templates/firstrun.php
@@ -59,7 +59,7 @@
 				</li>
 				<li>
 					<b><?php p($l->t('Custom fields')); ?></b><br />
-					<?php p($l->t('If the default fields are not enough your you, then you can add your own fields here.')); ?><br />
+					<?php p($l->t('If the default fields are not sufficient for you, then you can add your own fields here.')); ?><br />
 					<?php p($l->t('It also offers an option to let the value be hidden so it is handled as a password.')); ?>
 				</li>
 				<li>
@@ -67,7 +67,7 @@
 					<?php p($l->t('Passman has a built-in OTP (One Time Password) generator.')); ?><br />
 					<?php p($l->t('If you don\'t know what a OTP is then I suggest you enable it.')); ?><br />
 					<?php p($l->t('Services that have options for a One Time Password')); ?><br />
-					- <a href="https://help.github.com/articles/about-two-factor-authentication/" target="_blank"><?php p($l->t('Github'));?></a><br />
+					- <a href="https://help.github.com/articles/about-two-factor-authentication/" target="_blank"><?php p($l->t('GitHub'));?></a><br />
 					- <a href="https://www.google.com/landing/2step/" target="_blank"><?php p($l->t('Google')); ?></a><br />
 					- <a href="https://www.dropbox.com/en/help/363" target="_blank"><?php p($l->t('Dropbox')); ?></a><br />
 					- <a href="http://windows.microsoft.com/en-us/windows/two-step-verification-faq" target="_blank"><?php p($l->t('OneDrive')); ?></a><br />

--- a/templates/main.php
+++ b/templates/main.php
@@ -1187,8 +1187,7 @@
 
 <div id="encryptionKeyDialog" style="display: none;">
   <p><?php p($l->t('Enter your encryption key.')); ?></p>
-  <p><?php p($l->t('If this is the first time you use PassMan, this key will be used for encryption of your
-    passwords')); ?></p>
+  <p><?php p($l->t('If this is the first time you use Passman, this key will be used for encryption of your passwords')); ?></p>
   <input type="password" id="ecKey" style="width: 150px;" ng-enter="doLogin()"/><br/>
   <input type="checkbox" id="ecRemember" name="ecRemember"/><label for="ecRemember"><?php p($l->t('Remember this key ')); ?></label>
   <select id="rememberTime">


### PR DESCRIPTION
[Disclaimer: I hope this is the right file for the commit - I'm not familiar with the Transifex interaction with GitHub.]

There is currently a total of three different versions spelling the app's name "PassMan" in the strings for localisation on Transifex: "Passman", "PassMan" and "passman". Assuming the intended one is the one with the middle upper case "M", this pull request would correct the spelling to "PassMan". The other changes concern grammar ("passwords" in plural) and orthography ("this is", not "this if").