### PR TITLE
Further clean-up: Case sensitivity, more consistent, elegant wording

### DIFF
--- a/templates/main.php
+++ b/templates/main.php
@@ -882,8 +882,7 @@
         </div>
         <div ng-show="tabActive==3" class="row">
           <div class="col-md-11">
-            <p><?php p($l->t('Here you can indentify weak passwords, we will list the items. List all passwords with a rating less
-              than')); ?></p>
+            <p><?php p($l->t('Here you can indentify weak passwords, all affected items will be listed. List all passwords with a score less than')); ?></p>
             <input type="text" ng-model="settings.PSC.minStrength"/>
             <button class="btn" ng-click="checkPasswords()">Show weak passwords</button>
             <div ng-show="settings.PSC.weakItemList.length > 0">You've got {{settings.PSC.weakItemList.length}} weak passwords</div>
@@ -1171,7 +1170,7 @@
         </div>
       </div>
       <div ng-show="!userSettings.settings.sharing.shareKeys">
-              <?php p($l->t(' Generating sharing keys, this is a one time thing, please wait.')); ?>
+              <?php p($l->t(' Generating sharing keys. This step is only necessary once, please wait.')); ?>
       </div>
     </div>
   </div>

--- a/templates/main.php
+++ b/templates/main.php
@@ -510,7 +510,7 @@
           </div>
           <div class="col-xs-12 nopadding">
             <input type="file" qrread on-read="parseQR(qrdata)" ng-show="otpType==='image'"/>
-            <label ng-show="otpType==='string'"><?php p($l->t('Enter the 2 factor secret')); ?></label>
+            <label ng-show="otpType==='string'"><?php p($l->t('Enter the two-factor secret')); ?></label>
             <input type="text" ng-model="currentItem.otpsecret.secret" class="otpSecret form-control" ng-show="otpType==='string'"/>
           </div>
         </div>
@@ -784,7 +784,7 @@
             </div>
             <div class="col-xs-12 nopadding">
               <input type="file" qrread on-read="parseQR(qrdata)" ng-show="otpType==='image'"/>
-              <label ng-show="otpType==='string'"><?php p($l->t('Enter the 2 factor secret')); ?> <input type="text"
+              <label ng-show="otpType==='string'"><?php p($l->t('Enter the two-factor secret')); ?> <input type="text"
                                                                                    ng-model="currentItem.otpsecret.secret"
                                                                                    class="otpSecret"/></label>
             </div>
@@ -926,7 +926,7 @@
             <div><?php p($l->t('Export items as')); ?>
               <select ng-model="exportItemas" ng-init="exportItemas = 'csv'">
                 <option value="csv" selected="selected"><?php p($l->t('Passman CSV'));?></option>
-                <option value="keepasscsv"><?php p($l->t('Keepass CSV'));?></option>
+                <option value="keepasscsv"><?php p($l->t('KeePass CSV'));?></option>
                 <option value="json"><?php p($l->t('Passman JSON'));?></option>
                 <option value="xml"><?php p($l->t('Passman XML'));?></option>
               </select> <button class="btn btn-success" ng-click="exportItemAs(exportItemas)"><?php p($l->t('Export')); ?></button>
@@ -960,8 +960,8 @@
             <div><?php p($l->t('Import type')); ?>
               <select ng-model="importItemas" ng-init="importItemas = 'csv'">
                 <option value="csv" selected="selected"><?php p($l->t('Passman CSV'));?></option>
-                <option value="keepasscsv"><?php p($l->t('Keepass CSV'));?></option>
-                <option value="lastpasscsv"><?php p($l->t('Lastpass CSV'));?></option>
+                <option value="keepasscsv"><?php p($l->t('KeePass CSV'));?></option>
+                <option value="lastpasscsv"><?php p($l->t('LastPass CSV'));?></option>
                 <option value="json"><?php p($l->t('Passman JSON'));?></option>
                 <!--<option value="xml">Passman XML</option> -->
               </select></br>


### PR DESCRIPTION
* "2 factor" is now spelled as "two-factor" (as in http://en.wikipedia.org/wiki/Two_factor_authentication).
* "Keepass" is now spelled as "KeePass", c.f. http://keepass.info/.
* "Lastpass" is now spelled as "LastPass", c.f. https://lastpass.com/.
* "rating" is changed to "score", as "password score" is the term used by Passman on all other occasions.
* "we will list all items" is changed to "all affected items will be listed", which seems more elegant.
* The line break after line 885 is removed, the word "than" of the former line 886 is added to the sentence of line 885.
* "this is a one time thing" is changed to "This step is only necessary once", which is more elegant.