### PR TITLE
Re-applying corrections to orthography and grammar

### DIFF
--- a/templates/main.php
+++ b/templates/main.php
@@ -865,7 +865,7 @@
                 <label><input type="checkbox" ng-model="userSettings.settings.noFavIcons"><?php p($l->t('Disable favicons')); ?></label>
               </div>
               <div class="col-md-3 pull-right">
-                <h2><?php p($l->t('Change passman password')); ?></h2>
+                <h2><?php p($l->t('Change Passman password')); ?></h2>
                 <label><?php p($l->t('Current password')); ?></label> <input ng-model="changepw.oldpw" required>
                 <label><?php p($l->t('New password')); ?></label> <input ng-model="changepw.newpw" required>
                 <label><?php p($l->t('New password (repeat)')); ?></label><input ng-model="changepw.newpwr" required ng-enter="changePW()">
@@ -1194,8 +1194,7 @@
 
   <div id="encryptionKeyDialog" style="display: none;">
     <p><?php p($l->t('Enter your encryption key.')); ?></p>
-    <p><?php p($l->t('If this if the first time you use Passman, this key will be used for encryption your
-    passwords')); ?></p>
+    <p><?php p($l->t('If this is the first time you use Passman, this key will be used for encryption of your passwords')); ?></p>
     <input type="password" id="ecKey" style="width: 150px;"  ng-enter="doLogin()"/><br/>
     <input type="checkbox" id="ecRemember" name="ecRemember"/><label for="ecRemember"><?php p($l->t('Remember this key ')); ?></label>
     <select id="rememberTime">


### PR DESCRIPTION
Re-applying corrections to orthography and grammar of earlier commits, which apparently had been lost somewhere in the process of merging branches (?):

* Re-applied changes of commits https://github.com/brantje/passman/commit/6faaf571f0e5db19ce20a19b68147f174c431777 and https://github.com/brantje/passman/commit/9bd38f2ad0307ac45bd3ac99cbf0f73006acc858 to line [1197] (https://github.com/brantje/passman/blob/master/templates/main.php#L1197).
* Changed "passman" to "Passman" (with a capitalised "P") in accordance with the author's own explanation of his app's name given [here] (https://github.com/brantje/passman/pull/92#discussion_r23519905). :-)