### PR TITLE
Auto width addItem button

### DIFF
--- a/css/ocPassman.css
+++ b/css/ocPassman.css
@@ -221,7 +221,7 @@ div#topContent {
 	color: #555;
 }
 #addItem{
-	width: 120px;
+	width: auto;
 	white-space: nowrap; 
 }
 #addItem:disabled, #editItem:disabled, #deleteItem:disabled {


### PR DESCRIPTION
In French the text is longer than 120px. Automatic width is way better.

(Sorry for the change on the last line, I used the GitHub web interface to quickly edit this button)