### PR TITLE
Fix crash 9.0

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -11,6 +11,7 @@
 
 namespace OCA\Passman\AppInfo;
 \OCP\App::registerAdmin('passman', 'admin-settings');
+$l10n = new \OC_L10N('Passwords');
 \OCP\App::addNavigationEntry(array(
   // the string under which your app will be referenced in owncloud
   'id' => 'passman',
@@ -28,7 +29,7 @@ namespace OCA\Passman\AppInfo;
 
   // the title of your application. This will be used in the
   // navigation or on the settings page of your app
-  'name' => \OC_L10N::get('Passwords')->t('Passwords')
+  'name' => $l10n->t('Passwords')
 ));
 \OCP\Backgroundjob::registerJob('OCA\Passman\Cron\RunCron');
 \OC::$server->getActivityManager()->registerExtension(function() {


### PR DESCRIPTION
The 9.0.0RC1 just came out and passman crash.

But no big deal, just change two lines resolve the problem (but it's a crappy fix, because the OC_L10N is deprecated now).
